### PR TITLE
Open in a new tab

### DIFF
--- a/packages/review-vir/src/ui/elements/main-page-elements/pull-requests-main-page/pull-request-presentation/vir-pull-request.element.ts
+++ b/packages/review-vir/src/ui/elements/main-page-elements/pull-requests-main-page/pull-request-presentation/vir-pull-request.element.ts
@@ -267,7 +267,7 @@ export const VirPullRequest = defineElement<{
                                 `,
                             )}
                         </div>
-                        <a href=${inputs.pullRequest.id.htmlUrl}>
+                        <a href=${inputs.pullRequest.id.htmlUrl} target="_blank">
                             <b>#${inputs.pullRequest.id.prNumber}:</b>
                             ${inputs.pullRequest.id.title}
                         </a>

--- a/packages/review-vir/src/ui/elements/main-page-elements/pull-requests-main-page/pull-request-presentation/vir-pull-request.element.ts
+++ b/packages/review-vir/src/ui/elements/main-page-elements/pull-requests-main-page/pull-request-presentation/vir-pull-request.element.ts
@@ -230,7 +230,7 @@ export const VirPullRequest = defineElement<{
                     <div class="rows grow">
                         <div class="columns center">
                             <span class="faint no-shrink">
-                                <a href=${inputs.pullRequest.branches.headBranch.repo.htmlUrl}>
+                                <a href=${inputs.pullRequest.branches.headBranch.repo.htmlUrl} target="_blank">
                                     ${inputs.pullRequest.branches.headBranch.repo.repoName}
                                 </a>
                             </span>


### PR DESCRIPTION
I would like to have these open in a new tab so I can stay on the review-vir page and just click once to open the PRs in a new tab. It helps when I have review-vir in a pinned tab. 